### PR TITLE
Publish markers

### DIFF
--- a/include/socket_publisher/data_serializer.h
+++ b/include/socket_publisher/data_serializer.h
@@ -15,6 +15,7 @@ class config;
 namespace data {
 class keyframe;
 class landmark;
+class marker;
 } // namespace data
 
 namespace publish {
@@ -46,6 +47,7 @@ private:
     bool publish_points_ = true;
     std::unique_ptr<std::unordered_map<unsigned int, double>> keyframe_hash_map_;
     std::unique_ptr<std::unordered_map<unsigned int, double>> point_hash_map_;
+    std::unique_ptr<std::unordered_map<unsigned int, double>> marker_hash_map_;
 
     double current_pose_hash_ = 0;
     int frame_hash_ = 0;
@@ -61,6 +63,7 @@ private:
     std::string serialize_as_protobuf(const std::vector<std::shared_ptr<stella_vslam::data::keyframe>>& keyfrms,
                                       const std::vector<std::shared_ptr<stella_vslam::data::landmark>>& all_landmarks,
                                       const std::set<std::shared_ptr<stella_vslam::data::landmark>>& local_landmarks,
+                                      const std::vector<std::shared_ptr<stella_vslam::data::marker>>& all_markers,
                                       const stella_vslam::Mat44_t& current_camera_pose);
 
     std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len);

--- a/include/socket_publisher/data_serializer.h
+++ b/include/socket_publisher/data_serializer.h
@@ -37,6 +37,8 @@ public:
 
     std::string serialize_map_diff();
 
+    std::vector<std::string> serialize_map_diff(size_t max_keyframes, size_t max_landmarks);
+
     std::string serialize_latest_frame(const unsigned int image_quality_);
 
     static std::string serialized_reset_signal_;

--- a/protobuf/map_segment.proto
+++ b/protobuf/map_segment.proto
@@ -29,10 +29,17 @@ message map {
         string txt = 2;
     }
 
+    message marker {
+        uint32 id = 1;
+        repeated double coords = 2;
+        uint32 initialized = 3;
+    }
+
     Mat44 current_frame = 1;
     repeated keyframe keyframes = 2;
     repeated edge edges = 3;
     repeated landmark landmarks = 4;
     repeated uint32 local_landmarks = 5;
     repeated msg messages = 6;
+    repeated marker markers = 7;
 }

--- a/src/publisher.cc
+++ b/src/publisher.cc
@@ -28,6 +28,14 @@ void publisher::run() {
     const auto serialized_reset_signal = data_serializer::serialized_reset_signal_;
     client_->emit("map_publish", serialized_reset_signal);
 
+    // Too much data at once, when starting from a loaded map for example, seems
+    // to overload the socket viewer, so in the first step we'll send things in
+    // smaller chunks
+    auto first_map_data = data_serializer_->serialize_map_diff(1000, 1000); // What are good max sizes here?
+    for (auto& s : first_map_data)
+        if (!s.empty())
+            client_->emit("map_publish", s);
+
     while (true) {
         const auto t0 = std::chrono::system_clock::now();
 


### PR DESCRIPTION
There are two patches in this pull request:
 - one will make the 3D marker positions available to the socket viewer (this changes the protocol, a pull request for the socket viewer will be made as well)
 - I noticed that when sending an entire map over the connection, this did not seem to go well. For now, the data is split into smaller chunks, which seems to mitigate the problem. Perhaps a better solution exists though
 